### PR TITLE
Add folder actions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,23 +1,10 @@
-# Documentation Improvement Tasks
+# TODO: Implement Folder Operations for Coderrr
 
-## README.md Improvements
-- [x] Add table of contents
-- [x] Improve installation section with better examples
-- [x] Add more usage examples
-- [x] Enhance feature descriptions
-
-## API.md Improvements
-- [x] Clarify authentication setup
-- [x] Add more error examples
-- [x] Improve endpoint descriptions
-
-## Code Comments Improvements
-- [x] Enhance JSDoc in agent.js
-- [x] Add comments for complex methods in agent.js
-- [x] Explain retry logic in agent.js
-- [x] Enhance JSDoc in fileOps.js
-- [x] Add comments for complex methods in fileOps.js
-
-## Followup Steps
-- [x] Test documentation links and examples
-- [x] Verify code comments are accurate
+## Tasks
+- [x] Add `createDir` method to FileOperations class
+- [x] Add `deleteDir` method to FileOperations class (only deletes empty directories)
+- [x] Add `listDir` method to FileOperations class
+- [x] Add `renameDir` method to FileOperations class
+- [x] Update `execute` method to handle 'create_dir', 'delete_dir', 'list_dir', 'rename_dir' actions
+- [ ] Test new directory operations manually
+- [x] Update this TODO.md to mark tasks as completed


### PR DESCRIPTION
This pull request introduces support for directory operations in the project, including creating, deleting, listing, and renaming directories. The changes span backend API definitions, documentation, and the core file operations logic, ensuring directory actions are handled consistently alongside file operations.

### Directory Operations Support

* Added four new methods to the `FileOperations` class in `src/fileOps.js`: `createDir`, `deleteDir`, `listDir`, and `renameDir`, each with error handling and UI feedback for directory management.
* Updated the `execute` method in `FileOperations` to support the new directory actions: `create_dir`, `delete_dir`, `list_dir`, and `rename_dir`, with appropriate parameter handling.

### Backend API & Data Model Updates

* Extended the backend `Plan` model in `backend/main.py` to include new directory actions in the `action` field, and added `old_path`/`new_path` fields for `rename_dir`.
* Updated API response documentation and examples in `backend/main.py` to describe the new directory actions and their required fields. [[1]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L169-R176) [[2]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L188-R212)

### Documentation & Task Tracking

* Revised `TODO.md` to reflect the implementation and tracking of the new directory operations, replacing previous documentation improvement tasks.