### PR TITLE
feat: implement conversation history for multi-turn interactions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, model_validator, validator, ValidationErr
 from typing import Optional, Literal, List
 from dotenv import load_dotenv
 import asyncio
+from typing import Optional, List
 
 load_dotenv()
 
@@ -57,12 +58,19 @@ except Exception as e:
     raise RuntimeError(f"Failed to initialize AI client: {e}")
 
 
+# Conversation history message model
+class ConversationMessage(BaseModel):
+    role: str = Field(..., pattern="^(user|assistant)$")
+    content: str = Field(..., min_length=1, max_length=5000)
+
+
 # Request validation models
 class ChatRequest(BaseModel):
     prompt: str = Field(..., min_length=1, max_length=MAX_PROMPT_LENGTH)
     temperature: Optional[float] = Field(default=0.2, ge=0.0, le=2.0)
     max_tokens: Optional[int] = Field(default=2000, ge=1, le=4000)
     top_p: Optional[float] = Field(default=1.0, ge=0.0, le=1.0)
+    conversation_history: Optional[List[ConversationMessage]] = Field(default=None, max_items=20)
 
     @validator('prompt')
     def validate_prompt(cls, v):
@@ -279,13 +287,26 @@ async def chat(request: Request, raw_data: ChatRequest):
                 status_code=400,
                 detail=f"Invalid request format: {str(parse_error)}"
             )
-
-        # Build user message
+        
+        # Build messages list starting with system instructions
+        messages = [SystemMessage(content=SYSTEM_INSTRUCTIONS)]
+        
+        # Add conversation history if provided (for multi-turn context)
+        if chat_request.conversation_history:
+            for hist_msg in chat_request.conversation_history:
+                if hist_msg.role == "user":
+                    messages.append(UserMessage(content=f"Previous user request: {hist_msg.content}"))
+                else:  # assistant
+                    messages.append(UserMessage(content=f"Previous assistant response summary: {hist_msg.content}"))
+            print(f"[DEBUG] Including {len(chat_request.conversation_history)} history messages")
+        
+        # Build current user message
         user_message = f"User request: {chat_request.prompt}\n\nPlease output a JSON object with explanation and plan as described."
-
+        messages.append(UserMessage(content=user_message))
+        
         print(f"[INFO] Processing request from {client_ip}")
-        print(f"[DEBUG] Prompt length: {len(chat_request.prompt)} chars")
-
+        print(f"[DEBUG] Prompt length: {len(chat_request.prompt)} chars, Total messages: {len(messages)}")
+        
         # Call LLM with timeout
         try:
             response = await asyncio.wait_for(

--- a/src/agent.js
+++ b/src/agent.js
@@ -43,6 +43,41 @@ class Agent {
     this.codebaseContext = null; // Cached codebase structure
     this.scanOnFirstRequest = options.scanOnFirstRequest !== false; // Default to true
     this.gitEnabled = options.gitEnabled || false; // Git auto-commit feature (opt-in)
+    this.maxHistoryLength = options.maxHistoryLength || 10; // Max conversation turns to keep
+  }
+
+  /**
+   * Add a message to conversation history
+   * @param {string} role - 'user' or 'assistant'
+   * @param {string} content - Message content
+   */
+  addToHistory(role, content) {
+    this.conversationHistory.push({ role, content });
+    
+    // Trim history if it exceeds max length (keep most recent)
+    // Each turn = 2 messages (user + assistant), so maxHistoryLength * 2
+    const maxMessages = this.maxHistoryLength * 2;
+    if (this.conversationHistory.length > maxMessages) {
+      this.conversationHistory = this.conversationHistory.slice(-maxMessages);
+    }
+  }
+
+  /**
+   * Clear conversation history (useful for starting fresh)
+   */
+  clearHistory() {
+    this.conversationHistory = [];
+    ui.info('Conversation history cleared');
+  }
+
+  /**
+   * Get formatted conversation history for the backend
+   */
+  getFormattedHistory() {
+    return this.conversationHistory.map(msg => ({
+      role: msg.role,
+      content: msg.content
+    }));
   }
 
   /**
@@ -94,12 +129,20 @@ For command execution on ${osType}, use appropriate command separators (${osType
       const spinner = ui.spinner('Thinking...');
       spinner.start();
 
-      const response = await axios.post(`${this.backendUrl}/chat`, {
+      // Include conversation history for context continuity
+      const requestPayload = {
         prompt: enhancedPrompt,
         temperature: options.temperature || 0.2,
         max_tokens: options.max_tokens || 2000,
         top_p: options.top_p || 1.0
-      });
+      };
+
+      // Add conversation history if available (for multi-turn conversations)
+      if (this.conversationHistory.length > 0) {
+        requestPayload.conversation_history = this.getFormattedHistory();
+      }
+
+      const response = await axios.post(`${this.backendUrl}/chat`, requestPayload);
 
       spinner.stop();
 
@@ -483,16 +526,24 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
   /**
    * Main agent loop - process user request
    */
-  async process(userRequest) {
+  async process(userRequest, options = {}) {
+    const { trackHistory = true } = options;
+    
     try {
       ui.section('Processing Request');
       ui.info(`Request: ${userRequest}`);
+
+      // Add user message to history before processing
+      if (trackHistory) {
+        this.addToHistory('user', userRequest);
+      }
 
       // Get AI response
       const response = await this.chat(userRequest);
 
       // Try to parse JSON plan - handle both object responses (new backend) and string responses
       let plan;
+      let explanation = '';
       try {
         // If response is already an object with explanation/plan, use it directly
         const parsed = typeof response === 'object' && response !== null && response.plan
@@ -501,15 +552,28 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
 
         // Show explanation if present
         if (parsed.explanation) {
+          explanation = parsed.explanation;
           ui.section('Plan');
           console.log(parsed.explanation);
           ui.space();
         }
 
         plan = parsed.plan;
+        
+        // Add assistant response to history (summarized for context efficiency)
+        if (trackHistory) {
+          const historySummary = explanation || 
+            `Executed ${plan?.length || 0} step(s): ${plan?.map(s => s.summary || s.action).join(', ')}`;
+          this.addToHistory('assistant', historySummary);
+        }
       } catch (error) {
         ui.warning('Could not parse structured plan from response');
         console.log(response);
+        
+        // Still add to history even if parsing failed
+        if (trackHistory) {
+          this.addToHistory('assistant', response.substring(0, 500));
+        }
 
         const shouldContinue = await ui.confirm('Try manual execution mode?', false);
         if (!shouldContinue) {
@@ -538,11 +602,12 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
   }
 
   /**
-   * Interactive mode - continuous conversation
+   * Interactive mode - continuous conversation with history
    */
   async interactive() {
     ui.showBanner();
     ui.info('Interactive mode - Type your requests or "exit" to quit');
+    ui.info('Commands: "clear" (reset conversation), "history" (show context), "refresh" (rescan codebase)');
     ui.space();
 
     while (true) {
@@ -552,9 +617,54 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
         continue;
       }
 
-      if (request.toLowerCase() === 'exit' || request.toLowerCase() === 'quit') {
+      const command = request.toLowerCase().trim();
+      
+      // Handle special commands
+      if (command === 'exit' || command === 'quit') {
         ui.info('Goodbye! 👋');
         break;
+      }
+      
+      if (command === 'clear' || command === 'reset') {
+        this.clearHistory();
+        ui.success('Starting fresh conversation');
+        ui.space();
+        continue;
+      }
+      
+      if (command === 'history') {
+        if (this.conversationHistory.length === 0) {
+          ui.info('No conversation history yet');
+        } else {
+          ui.section(`Conversation History (${this.conversationHistory.length} messages)`);
+          this.conversationHistory.forEach((msg, i) => {
+            const prefix = msg.role === 'user' ? '👤 You:' : '🤖 Coderrr:';
+            const content = msg.content.length > 100 
+              ? msg.content.substring(0, 100) + '...' 
+              : msg.content;
+            console.log(`  ${i + 1}. ${prefix} ${content}`);
+          });
+        }
+        ui.space();
+        continue;
+      }
+      
+      if (command === 'refresh') {
+        this.refreshCodebase();
+        ui.space();
+        continue;
+      }
+      
+      if (command === 'help') {
+        ui.section('Available Commands');
+        console.log('  exit, quit    - Exit interactive mode');
+        console.log('  clear, reset  - Clear conversation history');
+        console.log('  history       - Show conversation history');
+        console.log('  refresh       - Rescan the codebase');
+        console.log('  help          - Show this help message');
+        console.log('  Or just type your coding request!');
+        ui.space();
+        continue;
       }
 
       await this.process(request);


### PR DESCRIPTION
This pull request adds support for multi-turn conversations by implementing conversation history in both the backend (`backend/main.py`) and the frontend agent (`src/agent.js`). The agent now tracks and manages conversation history, includes it in requests to the backend for better context, and provides interactive commands for users to manage their session. The backend validates and utilizes this history to improve AI responses.

**Conversation History Support**

* Introduced a `ConversationMessage` model in the backend and extended the `ChatRequest` to accept an optional `conversation_history` array, allowing up to 20 previous messages for context.
* Backend chat endpoint now builds the message list by including system instructions, conversation history (if provided), and the current user prompt, enhancing multi-turn conversation support.
* The frontend agent tracks conversation history, trims it to a configurable maximum length, and formats it for backend requests. Assistant responses are summarized before being added to history for efficiency. [[1]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6R46-R80) [[2]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6R555-R577)
* When sending a chat request, the agent now includes the formatted conversation history if available, enabling the backend to generate more context-aware responses.

**Interactive Mode Enhancements**

* Added interactive commands: `clear`/`reset` to clear history, `history` to display conversation context, `refresh` to rescan the codebase, and `help` to show available commands, improving usability for multi-turn sessions. [[1]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6L541-R610) [[2]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6L555-R669)