### PR TITLE
Add Separate testing frameworks based on languge used in codebase

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -477,9 +477,9 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
 
     const testCommands = [
       { cmd: 'npm test', file: 'package.json' },
+      { cmd: 'npx jest', file: 'jest.config.js' },
+      { cmd: 'npx jest', file: 'jest.config.ts' },
       { cmd: 'pytest', file: 'pytest.ini' },
-      { cmd: 'pytest', file: 'tests/' },
-      { cmd: 'python -m pytest', file: 'tests/' },
       { cmd: 'cargo test', file: 'Cargo.toml' },
       { cmd: 'go test ./...', file: 'go.mod' },
       { cmd: 'mvn test', file: 'pom.xml' },
@@ -493,6 +493,32 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
       if (fs.existsSync(filePath)) {
         testCommand = cmd;
         break;
+      }
+    }
+
+    if (!testCommand) {
+      const testDirs = ['tests', 'test'];
+      for (const dir of testDirs) {
+        const dirPath = path.join(this.workingDir, dir);
+        if (fs.existsSync(dirPath)) {
+          try {
+            const stats = fs.statSync(dirPath);
+            if (stats.isDirectory()) {
+              const files = fs.readdirSync(dirPath);
+              // Check for JS/TS files -> Jest
+              if (files.some(f => /\.(js|ts|jsx|tsx)$/.test(f))) {
+                testCommand = 'npx jest';
+                break;
+              }
+              if (files.some(f => /\.py$/.test(f))) {
+                testCommand = 'pytest';
+                break;
+              }
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This pull request enhances the logic for automatically detecting and selecting the appropriate test command in `src/agent.js`. The main improvements focus on expanding support for JavaScript/TypeScript and Python test setups, especially when explicit configuration files are missing.

**Test command detection improvements:**

* Added detection for Jest by checking for the presence of `jest.config.js` and `jest.config.ts` files, and associating them with the `npx jest` command.
* Implemented a fallback mechanism to scan for `tests` or `test` directories. If JavaScript/TypeScript files are found, `npx jest` is selected; if Python files are found, `pytest` is chosen. This helps ensure the correct test runner is used even without standard config files.