### PR TITLE
Add Separate testing frameworks based on languge used in codebase

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -477,9 +477,9 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
 
     const testCommands = [
       { cmd: 'npm test', file: 'package.json' },
+      { cmd: 'npx jest', file: 'jest.config.js' },
+      { cmd: 'npx jest', file: 'jest.config.ts' },
       { cmd: 'pytest', file: 'pytest.ini' },
-      { cmd: 'pytest', file: 'tests/' },
-      { cmd: 'python -m pytest', file: 'tests/' },
       { cmd: 'cargo test', file: 'Cargo.toml' },
       { cmd: 'go test ./...', file: 'go.mod' },
       { cmd: 'mvn test', file: 'pom.xml' },
@@ -493,6 +493,32 @@ Please provide ONLY a JSON object with the fixed step. Use the standard plan for
       if (fs.existsSync(filePath)) {
         testCommand = cmd;
         break;
+      }
+    }
+
+    if (!testCommand) {
+      const testDirs = ['tests', 'test'];
+      for (const dir of testDirs) {
+        const dirPath = path.join(this.workingDir, dir);
+        if (fs.existsSync(dirPath)) {
+          try {
+            const stats = fs.statSync(dirPath);
+            if (stats.isDirectory()) {
+              const files = fs.readdirSync(dirPath);
+              // Check for JS/TS files -> Jest
+              if (files.some(f => /\.(js|ts|jsx|tsx)$/.test(f))) {
+                testCommand = 'npx jest';
+                break;
+              }
+              if (files.some(f => /\.py$/.test(f))) {
+                testCommand = 'pytest';
+                break;
+              }
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This pull request enhances the logic for detecting and selecting the appropriate test command in `src/agent.js`. The main improvements include expanding the detection of test frameworks, especially for JavaScript/TypeScript and Python projects, by checking for specific config files and inspecting test directories.

**Test command detection improvements:**

* Added detection for Jest by checking for the presence of `jest.config.js` and `jest.config.ts` files, and associating them with the `npx jest` command.
* Introduced logic to scan common test directories (`tests`, `test`) for JavaScript/TypeScript or Python files and automatically select `npx jest` or `pytest` as the test command based on the file types found.