### PR TITLE
Update CI pipeline to avoid nodejs testing error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "url": "https://github.com/sponsors/Akash-nath29"
   },
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=18.0.0",
     "npm": ">=7.0.0"
   },
   "os": [


### PR DESCRIPTION
This pull request updates the Node.js version requirements across the project to ensure compatibility with newer Node.js releases and to phase out support for older versions.

Node.js version upgrades:

* Updated the CI workflow matrix in `.github/workflows/ci.yml` to test against Node.js versions 18.x, 20.x, and 22.x, removing support for 16.x.
* Increased the minimum required Node.js version in the `package.json` `engines` field from 16.0.0 to 18.0.0.