### PR TITLE
solved Insufficient Validation of AI-Generated Fixes in Self-Healing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,29 @@
-# TODO: Implement Folder Operations for Coderrr
+# Task: Fix Insufficient Validation of AI-Generated Fixes in Self-Healing
 
-## Tasks
-- [x] Add `createDir` method to FileOperations class
-- [x] Add `deleteDir` method to FileOperations class (only deletes empty directories)
-- [x] Add `listDir` method to FileOperations class
-- [x] Add `renameDir` method to FileOperations class
-- [x] Update `execute` method to handle 'create_dir', 'delete_dir', 'list_dir', 'rename_dir' actions
-- [ ] Test new directory operations manually
-- [x] Update this TODO.md to mark tasks as completed
+## Issue Description
+In src/agent.js, the selfHeal method requests AI-generated fixes for failed steps, but the validation of the returned fixed_step object is incomplete. While it checks for the presence of command for run_command actions, it does not validate required fields for file operations (e.g., path, content, oldContent, newContent), allowing invalid fixes to proceed and cause subsequent failures.
+
+## Solution Implemented
+
+### Changes Made:
+- [x] Added `validateFixedStep()` method in `src/agent.js` that validates required fields based on action type:
+  - `run_command`: requires `command` (string, non-empty)
+  - `create_file`/`update_file`: requires `path` (string, non-empty) and `content` (string)
+  - `patch_file`: requires `path`, `oldContent`, and `newContent` (all strings, non-empty)
+  - `delete_file`/`read_file`/`create_dir`/`delete_dir`/`list_dir`: requires `path` (string, non-empty)
+  - `rename_dir`: requires either `path`+`newPath` or `oldPath`+`newPath` (all strings, non-empty)
+
+- [x] Updated both retry logic blocks in `executePlan()` method to use `this.validateFixedStep(fixedStep)` instead of the incomplete validation that only checked for `command` field
+
+### Validation Logic:
+The new validation ensures that:
+1. The fixed step is a valid object
+2. It has an `action` field
+3. Based on the action type, all required fields are present and are non-empty strings where applicable
+
+### Testing:
+- The validation will now prevent retries with incomplete AI-generated fixes
+- Invalid fixes will be rejected, and the agent will either skip retrying or ask the user for intervention
+- This prevents cascading failures from malformed AI responses
+
+## Status: COMPLETED ✅


### PR DESCRIPTION
This pull request improves the validation of AI-generated fixes in the self-healing workflow. Previously, only minimal checks were performed, which could allow incomplete or invalid fixes to be retried and cause further failures. The new logic ensures that every AI-generated fix is properly validated for required fields based on its action type before being retried, leading to more robust error handling and prevention of cascading failures.

**Validation Improvements:**

* Added a new `validateFixedStep()` method in `src/agent.js` that checks for the presence and validity of required fields for each action type (e.g., `command`, `path`, `content`, etc.).

* Updated both retry logic blocks in the `executePlan()` method to use `this.validateFixedStep(fixedStep)` instead of the previous incomplete validation, ensuring that only valid fixes are retried. [[1]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6L333-R334) [[2]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6L379-R378)

**Documentation Update:**

* Replaced the previous folder operations TODOs in `TODO.md` with a detailed description of the validation issue, the solution, and testing notes, reflecting the new focus on robust validation of AI-generated fixes.