### PR TITLE
Add Skills feature: Custom Skills in Skills.md

### DIFF
--- a/src/fileOps.js
+++ b/src/fileOps.js
@@ -13,6 +13,7 @@ const ui = require('./ui');
 // Protected paths that should never be deleted by Coderrr
 const PROTECTED_PATHS = [
   'Coderrr.md',
+  'Skills.md',
   '.coderrr'
 ];
 

--- a/tests/unit/skills.test.js
+++ b/tests/unit/skills.test.js
@@ -1,0 +1,194 @@
+const fs = require('fs');
+const path = require('path');
+const Agent = require('../../src/agent');
+
+// Mock dependencies
+jest.mock('../../src/ui', () => ({
+    info: jest.fn(),
+    warning: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+    spinner: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() })),
+    section: jest.fn(),
+    space: jest.fn(),
+    confirm: jest.fn(),
+    displayFileOp: jest.fn(),
+    displayDiff: jest.fn()
+}));
+
+jest.mock('../../src/configManager', () => ({
+    initializeProjectStorage: jest.fn(),
+    loadProjectMemory: jest.fn(() => []),
+    saveProjectMemory: jest.fn(),
+    clearProjectMemory: jest.fn(),
+    getConfig: jest.fn()
+}));
+
+jest.mock('axios');
+
+describe('Skills.md Loading', () => {
+    let tempDir;
+    const originalCwd = process.cwd();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Create a temporary directory for testing
+        tempDir = path.join(originalCwd, 'test-temp-skills');
+        if (!fs.existsSync(tempDir)) {
+            fs.mkdirSync(tempDir, { recursive: true });
+        }
+    });
+
+    afterEach(() => {
+        // Clean up temporary directory
+        if (fs.existsSync(tempDir)) {
+            const files = fs.readdirSync(tempDir);
+            for (const file of files) {
+                fs.unlinkSync(path.join(tempDir, file));
+            }
+            fs.rmdirSync(tempDir);
+        }
+    });
+
+    describe('loadSkillsPrompt', () => {
+        it('should load Skills.md when it exists', () => {
+            const skillsContent = '# Frontend Skills\n- Use modern design patterns';
+            fs.writeFileSync(path.join(tempDir, 'Skills.md'), skillsContent);
+
+            const agent = new Agent({ workingDir: tempDir });
+            agent.loadSkillsPrompt();
+
+            expect(agent.skillsPrompt).toBe(skillsContent);
+        });
+
+        it('should not set skillsPrompt when Skills.md does not exist', () => {
+            const agent = new Agent({ workingDir: tempDir });
+            agent.loadSkillsPrompt();
+
+            expect(agent.skillsPrompt).toBeNull();
+        });
+
+        it('should handle empty Skills.md gracefully', () => {
+            fs.writeFileSync(path.join(tempDir, 'Skills.md'), '   ');
+
+            const agent = new Agent({ workingDir: tempDir });
+            agent.loadSkillsPrompt();
+
+            expect(agent.skillsPrompt).toBe('');
+        });
+    });
+
+    describe('loadCustomPrompt', () => {
+        it('should load Coderrr.md when it exists', () => {
+            const taskContent = '# Task: Build landing page';
+            fs.writeFileSync(path.join(tempDir, 'Coderrr.md'), taskContent);
+
+            const agent = new Agent({ workingDir: tempDir });
+            agent.loadCustomPrompt();
+
+            expect(agent.customPrompt).toBe(taskContent);
+        });
+
+        it('should not set customPrompt when Coderrr.md does not exist', () => {
+            const agent = new Agent({ workingDir: tempDir });
+            agent.loadCustomPrompt();
+
+            expect(agent.customPrompt).toBeNull();
+        });
+    });
+
+    describe('Prompt Priority Order', () => {
+        it('should construct prompt with Skills.md before Coderrr.md', () => {
+            const skillsContent = '# Skills\n- Be modern';
+            const taskContent = '# Task\n- Build a form';
+            fs.writeFileSync(path.join(tempDir, 'Skills.md'), skillsContent);
+            fs.writeFileSync(path.join(tempDir, 'Coderrr.md'), taskContent);
+
+            const agent = new Agent({ workingDir: tempDir, scanOnFirstRequest: false });
+            agent.loadSkillsPrompt();
+            agent.loadCustomPrompt();
+
+            // Simulate prompt construction (from chat method logic)
+            let enhancedPrompt = 'User request';
+
+            // Task guidance first (will be wrapped by skills)
+            if (agent.customPrompt) {
+                enhancedPrompt = `[TASK GUIDANCE]\n${agent.customPrompt}\n\n[USER REQUEST]\n${enhancedPrompt}`;
+            }
+
+            // Skills prepended (comes before everything else)
+            if (agent.skillsPrompt) {
+                enhancedPrompt = `[SKILLS]\n${agent.skillsPrompt}\n\n${enhancedPrompt}`;
+            }
+
+            // Verify priority order: Skills comes first
+            expect(enhancedPrompt.startsWith('[SKILLS]')).toBe(true);
+            expect(enhancedPrompt.indexOf('[SKILLS]')).toBeLessThan(enhancedPrompt.indexOf('[TASK GUIDANCE]'));
+            expect(enhancedPrompt.indexOf('[TASK GUIDANCE]')).toBeLessThan(enhancedPrompt.indexOf('[USER REQUEST]'));
+        });
+
+        it('should work with only Skills.md (no Coderrr.md)', () => {
+            const skillsContent = '# Skills\n- Be creative';
+            fs.writeFileSync(path.join(tempDir, 'Skills.md'), skillsContent);
+
+            const agent = new Agent({ workingDir: tempDir, scanOnFirstRequest: false });
+            agent.loadSkillsPrompt();
+            agent.loadCustomPrompt();
+
+            let enhancedPrompt = 'User request';
+
+            if (agent.customPrompt) {
+                enhancedPrompt = `[TASK GUIDANCE]\n${agent.customPrompt}\n\n[USER REQUEST]\n${enhancedPrompt}`;
+            }
+
+            if (agent.skillsPrompt) {
+                enhancedPrompt = `[SKILLS]\n${agent.skillsPrompt}\n\n${enhancedPrompt}`;
+            }
+
+            expect(enhancedPrompt).toContain('[SKILLS]');
+            expect(enhancedPrompt).not.toContain('[TASK GUIDANCE]');
+            expect(enhancedPrompt).toContain('User request');
+        });
+
+        it('should work with only Coderrr.md (no Skills.md)', () => {
+            const taskContent = '# Task\n- Do something';
+            fs.writeFileSync(path.join(tempDir, 'Coderrr.md'), taskContent);
+
+            const agent = new Agent({ workingDir: tempDir, scanOnFirstRequest: false });
+            agent.loadSkillsPrompt();
+            agent.loadCustomPrompt();
+
+            let enhancedPrompt = 'User request';
+
+            if (agent.customPrompt) {
+                enhancedPrompt = `[TASK GUIDANCE]\n${agent.customPrompt}\n\n[USER REQUEST]\n${enhancedPrompt}`;
+            }
+
+            if (agent.skillsPrompt) {
+                enhancedPrompt = `[SKILLS]\n${agent.skillsPrompt}\n\n${enhancedPrompt}`;
+            }
+
+            expect(enhancedPrompt).not.toContain('[SKILLS]');
+            expect(enhancedPrompt).toContain('[TASK GUIDANCE]');
+            expect(enhancedPrompt).toContain('User request');
+        });
+
+        it('should work with neither Skills.md nor Coderrr.md', () => {
+            const agent = new Agent({ workingDir: tempDir, scanOnFirstRequest: false });
+            agent.loadSkillsPrompt();
+            agent.loadCustomPrompt();
+
+            let enhancedPrompt = 'User request';
+
+            if (agent.customPrompt) {
+                enhancedPrompt = `[TASK GUIDANCE]\n${agent.customPrompt}\n\n[USER REQUEST]\n${enhancedPrompt}`;
+            }
+
+            if (agent.skillsPrompt) {
+                enhancedPrompt = `[SKILLS]\n${agent.skillsPrompt}\n\n${enhancedPrompt}`;
+            }
+
+            expect(enhancedPrompt).toBe('User request');
+        });
+    });
+});


### PR DESCRIPTION
This pull request adds support for persistent project skills via a new `Skills.md` file and refines how system prompts are constructed in the `Agent` class. It introduces logic to load and prioritize skills and task-specific guidance, updates the prompt-building order, ensures `Skills.md` is protected from deletion, and includes comprehensive unit tests for the new functionality.

**Skills prompt integration and prompt construction:**

- Added support for loading a persistent skills prompt from `Skills.md` in the project directory, which is used to provide general guidance for all tasks. The prompt from `Skills.md` is loaded on the first chat request if not already loaded. (`src/agent.js` [[1]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6L49-R50) [[2]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6R88-R113) [[3]](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6R145-R149)
- Updated the prompt construction logic to prepend the skills prompt (from `Skills.md`) before the task-specific prompt (from `Coderrr.md`), ensuring the priority order is: system prompt, skills, task guidance, and user request. (`src/agent.js` [src/agent.jsL147-R184](diffhunk://#diff-89117af8b81bfeaf722beddae7606e64d109539455e3ee58d81f73e90bd228e6L147-R184))

**File protection:**

- Added `Skills.md` to the list of protected files that cannot be deleted by the application to prevent accidental loss of persistent skills. (`src/fileOps.js` [src/fileOps.jsR16](diffhunk://#diff-d56bb7dd9076325f67b3d375a0e63283a21b5c20014dbf640770520ee500f52dR16))

**Testing:**

- Added a new unit test suite (`skills.test.js`) to verify loading of `Skills.md`, the prompt construction order, and handling of various scenarios (both files present, only one present, or neither). (`tests/unit/skills.test.js` [tests/unit/skills.test.jsR1-R194](diffhunk://#diff-2946742ef7fc2f69684feb72c9256d629683e2e328169ccc1fa9f2ef4d3f3077R1-R194))