### PR TITLE
fix(config): convert rate_limit to computed property and clean settin…

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,29 +1,41 @@
 """
-This file includes the config of the app. Contains the environment variables.
-It defines a Pydantic BaseSettings class and caches a single Settings instance.
+This file includes the config of the app.
+
+Contains environment variables using Pydantic BaseSettings
+and caches a single Settings instance.
 """
 
 from functools import lru_cache
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 class Settings(BaseSettings):
     token: str = Field(..., validation_alias="GITHUB_TOKEN")
-    endpoint: str = Field("https://models.github.ai/inference", validation_alias="GITHUB_MODELS_ENDPOINT")
+    endpoint: str = Field(
+        "https://models.github.ai/inference",
+        validation_alias="GITHUB_MODELS_ENDPOINT",
+    )
     model_name: str = Field("openai/gpt-4o", validation_alias="GITHUB_MODEL")
     max_prompt_length: int = Field(10000, validation_alias="MAX_PROMPT_LENGTH")
     max_request_size: int = Field(50000, validation_alias="MAX_REQUEST_SIZE")
     llm_timeout: int = Field(1200, validation_alias="LLM_TIMEOUT")
+
     rate_limit_window: int = 60
     rate_limit_max_requests: int = 30
+
+    @property
+    def rate_limit(self) -> str:
+        return f"{self.rate_limit_max_requests} requests per {self.rate_limit_window}s"
+
     version: str = "1.1.0"
-    rate_limit: str = f"{rate_limit_max_requests} requests per {rate_limit_window}s"
 
     model_config = SettingsConfigDict(
         env_file=".env",
-        case_sensitive=True
+        case_sensitive=True,
     )
 
-@lru_cache
+
+@lru_cache()
 def get_settings() -> Settings:
     return Settings()


### PR DESCRIPTION
# Pull Request

## Description

Fixes incorrect `rate_limit` evaluation in the settings module by converting it from a static class attribute to a computed property. This ensures the rate limit value correctly reflects environment variable changes at runtime.

Fixes #131

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Changes Made

- Converted `rate_limit` to a computed `@property`
- Fixed incorrect class-level evaluation of dependent fields
- Improved readability and formatting of the settings module

## Motivation and Context

The `rate_limit` value was being evaluated at import time, causing it to remain static even when environment variables were changed. This led to incorrect rate limit reporting and confusion during debugging. This change ensures accurate, runtime-derived configuration values.

## Testing

**Test Configuration**
- OS: Windows 11
- Node.js Version: 18.17.0
- Python Version: 3.11.x


