### PR TITLE
Dev

### DIFF
--- a/src/coderrr/sandbox/scratch.py
+++ b/src/coderrr/sandbox/scratch.py
@@ -144,14 +144,14 @@ class ScratchSandbox:
         )
 
         timed_out = False
+        stdout_b, stderr_b = b"", b""
         try:
             stdout_b, stderr_b = await asyncio.wait_for(process.communicate(), timeout=limit)
         except asyncio.TimeoutError:
             timed_out = True
             _kill_tree(process)
             with contextlib.suppress(Exception):
-                await process.wait()
-            stdout_b, stderr_b = b"", b""
+                stdout_b, stderr_b = await process.communicate()
 
         return ExecResult(
             command=command,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test support package."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker for stable test imports."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from tests.fakes import RecordingConsole
 
 from coderrr.agent.modes import AgentMode
 from coderrr.config import Config
@@ -19,6 +18,7 @@ from coderrr.spec.store import SpecStore
 from coderrr.tools.base import ToolContext
 from coderrr.tools.registry import ToolRegistry
 from coderrr.verify import NullVerifier
+from tests.fakes import RecordingConsole
 
 
 @pytest.fixture

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from tests.fakes import FakeProvider, Turn
-
 from coderrr.agent.loop import run_conversation, run_task
 from coderrr.agent.modes import AgentMode
 from coderrr.llm.types import Message
 from coderrr.tools.base import ToolContext
 from coderrr.tools.registry import ToolRegistry
+from tests.fakes import FakeProvider, Turn
 
 
 async def _run(provider, registry, ctx, text="do the thing"):  # type: ignore[no-untyped-def]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tests.fakes import FakeProvider, RecordingConsole, Turn
-
 from coderrr.agent.modes import AgentMode
 from coderrr.agent.session import Session
 from coderrr.config import Config
 from coderrr.llm.types import ToolResultBlock
+from tests.fakes import FakeProvider, RecordingConsole, Turn
 
 REQS_MD = "# Requirements: Add a greeting\n\nAdd farewell()."
 DESIGN_MD = "# Design: Add a greeting\n\nOne function."


### PR DESCRIPTION
This pull request refactors test imports to improve clarity and maintain best practices. The most important changes include reordering and grouping test utility imports for consistency, and adding a package marker for stable test imports.

**Test import organization:**

* Reordered the import of `RecordingConsole` in `tests/conftest.py` to group all test utility imports together, improving readability and consistency. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L12) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R21)
* Moved the import of `FakeProvider` and `Turn` in `tests/test_loop.py` to appear after standard library and project imports, aligning with import conventions.
* Adjusted the import order of `FakeProvider`, `RecordingConsole`, and `Turn` in `tests/test_session.py` to group them with other test utilities.

**Test package structure:**

* Added a `__init__.py` marker file to the `tests` package to ensure stable test imports.