### PR TITLE
Surface provider error details and make verifier temperature configurable

### DIFF
--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -1,34 +1,31 @@
 name: v2 (Python)
 
-# Quality gates here are blocking. v1's workflow marked every lint and security
-# step `continue-on-error: true`, which meant npm audit and the linters could
-# never fail a build. Do not reintroduce that.
+# Every gate here is blocking. v1's workflow marked its lint and security steps
+# `continue-on-error: true`, which meant they could never fail a build. Do not
+# reintroduce that.
 
 on:
   push:
     branches: [v2, main]
-    paths:
-      - "src/coderrr/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - ".github/workflows/v2.yml"
   pull_request:
     branches: [v2, main]
-    paths:
-      - "src/coderrr/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - ".github/workflows/v2.yml"
+
+permissions:
+  contents: read
 
 concurrency:
-  group: v2-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Superseded PR pushes are cancelled. Post-merge runs on v2/main are not --
+  # those are the record of whether the branch is green.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Preserved from the retired v1 workflow: feature -> dev -> main.
+  # Branching policy: feature -> dev/v2 -> main. A repository ruleset enforces
+  # this more strongly and cannot be bypassed; this job is the portable version.
   branch-workflow:
     name: Validate branch workflow
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
       - name: Block direct feature-to-main PRs
@@ -41,25 +38,21 @@ jobs:
           echo "::error::Open your PR against 'dev' (or 'v2'), which is then merged to main."
           exit 1
 
-      - name: Workflow valid
-        run: echo "Branch workflow is valid."
-
   quality:
     name: Lint & types
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      UV_PYTHON: "3.12"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
 
-      - name: Set up Python
-        run: uv python install 3.12
-
       - name: Install
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras
 
       - name: Ruff lint
         run: uv run ruff check src tests
@@ -73,34 +66,36 @@ jobs:
   test:
     name: Tests (${{ matrix.os }}, py${{ matrix.python }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    env:
+      UV_PYTHON: ${{ matrix.python }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          # Keep the matrix affordable: only the floor and ceiling off-Linux.
-          - { os: macos-latest, python: "3.11" }
-          - { os: macos-latest, python: "3.12" }
-          - { os: windows-latest, python: "3.11" }
-          - { os: windows-latest, python: "3.12" }
+        include:
+          # The floor, and the only interpreter on the tomli (not tomllib) path
+          # -- see the version guard in src/coderrr/config.py.
+          - { os: ubuntu-latest, python: "3.10" }
+          # The ceiling, and what most contributors actually run.
+          - { os: ubuntu-latest, python: "3.13" }
+          # The only non-POSIX branch shipped -- sandbox/scratch.py guards on
+          # os.name, and Windows subprocess cleanup has regressed before.
+          - { os: windows-latest, python: "3.13" }
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
 
-      - name: Set up Python
-        run: uv python install ${{ matrix.python }}
-
       - name: Install
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras
 
       - name: Test
         run: uv run pytest -q
 
+      # Also covers Windows, where the standalone wheel check below does not run
+      # -- console-script wiring is precisely what breaks there.
       - name: CLI smoke test
         run: |
           uv run coderrr version
@@ -110,12 +105,14 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [quality, test]
+    env:
+      UV_PYTHON: "3.12"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5
 
       - name: Build
         run: uv build
@@ -130,3 +127,4 @@ jobs:
         with:
           name: dist
           path: dist/
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ token.txt
 # they are project knowledge and belong in version control.
 .coderrr/cache/
 .coderrr/session/
+agent_docs/*
+.claude/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+## Git Restrictions
+
+- **Do NOT run write-based git commands.** This includes (but is not limited to): `git push`, `git pull`, `git commit`, `git add`, `git merge`, `git rebase`, `git reset`, `git checkout` (when it modifies state), `git stash`, `git tag`, `git branch -d/-D`, and any other command that alters repository state.
+- **Read-only git commands are allowed.** For example: `git status`, `git log`, `git diff`, `git show`, `git branch` (list), `git remote -v`, `git blame`.
+- If a task seems to require a write-based git command, **stop and ask me** to run it myself or to explicitly approve it.
+
+## Workflow: Plan First, Code Only on Approval
+
+- **Always plan before acting.** When given a task, first present a clear plan describing what you intend to do and how.
+- **Do NOT write, edit, or execute code** until I explicitly give a green flag (e.g., "go ahead", "execute", "proceed", "do it").
+- Presenting a plan is not permission to implement it — wait for my confirmation.
+- If any part of the task is ambiguous or has unknown variables, **ask me before proceeding** rather than making assumptions.

--- a/src/coderrr/config.py
+++ b/src/coderrr/config.py
@@ -70,6 +70,11 @@ class VerifyConfig(BaseModel):
     #: Empty means reuse the main model. Point this at something cheap.
     model: str = ""
     batch: bool = True
+    #: Sampling temperature for the verifier call. Kept above zero so a weak
+    #: model that spuriously rejects a valid write does not do so identically on
+    #: every retry -- at 0.0 a false "reject" is deterministic and the retry
+    #: loop can never escape it.
+    temperature: float = Field(default=0.3, ge=0.0, le=2.0)
 
 
 class SandboxConfig(BaseModel):

--- a/src/coderrr/llm/anthropic.py
+++ b/src/coderrr/llm/anthropic.py
@@ -199,7 +199,10 @@ class AnthropicProvider:
                                 f"anthropic stream error: {err.get('message', 'unknown')}"
                             )
             except httpx.HTTPError as exc:
-                raise ProviderError(f"anthropic request failed: {exc}") from exc
+                # Timeout/read errors stringify to "", so fall back to the class
+                # name to avoid an empty "request failed:" message.
+                detail = str(exc).strip() or type(exc).__name__
+                raise ProviderError(f"anthropic request failed: {detail}") from exc
 
         yield MessageStop(
             stop_reason=stop_reason,

--- a/src/coderrr/llm/google.py
+++ b/src/coderrr/llm/google.py
@@ -195,6 +195,9 @@ class GoogleProvider:
                                     )
                                     stop_reason = "tool_use"
             except httpx.HTTPError as exc:
-                raise ProviderError(f"google request failed: {exc}") from exc
+                # Timeout/read errors stringify to "", so fall back to the class
+                # name to avoid an empty "request failed:" message.
+                detail = str(exc).strip() or type(exc).__name__
+                raise ProviderError(f"google request failed: {detail}") from exc
 
         yield MessageStop(stop_reason=stop_reason, usage=usage)

--- a/src/coderrr/llm/openai_compat.py
+++ b/src/coderrr/llm/openai_compat.py
@@ -213,7 +213,11 @@ class OpenAICompatProvider:
                                         partial_json=fn["arguments"],
                                     )
             except httpx.HTTPError as exc:
-                raise ProviderError(f"{self.name} request failed: {exc}") from exc
+                # Timeout/read errors (httpx.ReadTimeout, ConnectTimeout, ...)
+                # stringify to "", so fall back to the class name to avoid an
+                # empty "request failed:" message.
+                detail = str(exc).strip() or type(exc).__name__
+                raise ProviderError(f"{self.name} request failed: {detail}") from exc
 
         # A model that emitted tool calls is requesting execution even when the
         # endpoint reports a generic finish reason -- Ollama does this.

--- a/src/coderrr/ui/console.py
+++ b/src/coderrr/ui/console.py
@@ -59,6 +59,16 @@ def _encodable(text: str, stream: IO[str]) -> bool:
     return True
 
 
+def _icons_for(*, encodable: bool, legacy_windows: bool) -> dict[str, str]:
+    """Pick the icon set from the two things that can go wrong.
+
+    A legacy console gets ASCII chrome even when it *can* encode the glyphs,
+    matching how Rich chooses its own box characters. Kept separate from the
+    console so both signals can be tested without a Windows host.
+    """
+    return _ICONS if encodable and not legacy_windows else _ASCII_ICONS
+
+
 def _degrade_unencodable(stream: IO[str]) -> None:
     """Print unencodable characters as ``?`` rather than killing the process.
 
@@ -80,9 +90,10 @@ class Console:
     def __init__(self, *, quiet: bool = False, interactive: bool = True) -> None:
         self._console = RichConsole()
         encodable = _encodable("".join(_ICONS.values()), self._console.file)
-        # A legacy console gets ASCII chrome even when it could encode the
-        # glyphs, matching how Rich picks its own box characters.
-        self._icons = _ICONS if encodable and not self._console.legacy_windows else _ASCII_ICONS
+        self._icons = _icons_for(
+            encodable=encodable,
+            legacy_windows=self._console.legacy_windows,
+        )
         if not encodable:
             _degrade_unencodable(self._console.file)
         self.quiet = quiet

--- a/src/coderrr/ui/console.py
+++ b/src/coderrr/ui/console.py
@@ -6,9 +6,10 @@ tests can swap in a quiet implementation without touching agent code.
 
 from __future__ import annotations
 
+import contextlib
 import difflib
 from collections.abc import Sequence
-from typing import Any
+from typing import IO, Any
 
 from rich.console import Console as RichConsole
 from rich.markdown import Markdown
@@ -28,12 +29,62 @@ _ICONS = {
     "write": "~",
 }
 
+# Windows consoles still default to cp1252 or cp437, and neither can encode most
+# of the glyphs above. Rich already falls back for its own boxes and rules; these
+# icons are ours, so the fallback has to be too.
+_ASCII_ICONS = {
+    "info": "-",
+    "success": "+",
+    "warning": "!",
+    "error": "x",
+    "tool": "*",
+    "read": "?",
+    "write": "~",
+}
+
+
+def _encodable(text: str, stream: IO[str]) -> bool:
+    """Whether ``stream`` can represent ``text`` in its own encoding.
+
+    A stream with no encoding (an in-memory buffer, a test double) never runs
+    the encode step, so nothing can fail there.
+    """
+    encoding = getattr(stream, "encoding", None)
+    if not encoding:
+        return True
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
+def _degrade_unencodable(stream: IO[str]) -> None:
+    """Print unencodable characters as ``?`` rather than killing the process.
+
+    Our own chrome is a fixed set we can substitute, but most of what reaches a
+    terminal is model-generated -- an arrow in a spec, an em dash in a summary.
+    Under the default ``strict`` handler a single such character raises
+    ``UnicodeEncodeError`` halfway through a command and loses the work.
+    """
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is None:
+        return
+    with contextlib.suppress(OSError, ValueError):  # already detached or read-only
+        reconfigure(errors="replace")
+
 
 class Console:
     """Rich-backed console with the prompts the agent needs."""
 
     def __init__(self, *, quiet: bool = False, interactive: bool = True) -> None:
         self._console = RichConsole()
+        encodable = _encodable("".join(_ICONS.values()), self._console.file)
+        # A legacy console gets ASCII chrome even when it could encode the
+        # glyphs, matching how Rich picks its own box characters.
+        self._icons = _ICONS if encodable and not self._console.legacy_windows else _ASCII_ICONS
+        if not encodable:
+            _degrade_unencodable(self._console.file)
         self.quiet = quiet
         self.interactive = interactive
 
@@ -44,16 +95,16 @@ class Console:
             self._console.print(*args, **kwargs)
 
     def info(self, message: str) -> None:
-        self.print(f"[cyan]{_ICONS['info']}[/] {message}")
+        self.print(f"[cyan]{self._icons['info']}[/] {message}")
 
     def success(self, message: str) -> None:
-        self.print(f"[green]{_ICONS['success']}[/] {message}")
+        self.print(f"[green]{self._icons['success']}[/] {message}")
 
     def warning(self, message: str) -> None:
-        self.print(f"[yellow]{_ICONS['warning']}[/] {message}")
+        self.print(f"[yellow]{self._icons['warning']}[/] {message}")
 
     def error(self, message: str) -> None:
-        self.print(f"[red]{_ICONS['error']}[/] {message}")
+        self.print(f"[red]{self._icons['error']}[/] {message}")
 
     def rule(self, title: str = "") -> None:
         if not self.quiet:
@@ -86,10 +137,10 @@ class Console:
 
     def tool_call(self, name: str, summary: str = "") -> None:
         detail = f" [dim]{summary}[/]" if summary else ""
-        self.print(f"  [magenta]{_ICONS['tool']}[/] [bold]{name}[/]{detail}")
+        self.print(f"  [magenta]{self._icons['tool']}[/] [bold]{name}[/]{detail}")
 
     def tool_result(self, name: str, ok: bool, detail: str = "") -> None:
-        icon = f"[green]{_ICONS['success']}[/]" if ok else f"[red]{_ICONS['error']}[/]"
+        icon = f"[green]{self._icons['success']}[/]" if ok else f"[red]{self._icons['error']}[/]"
         suffix = f" [dim]{detail}[/]" if detail else ""
         self.print(f"    {icon} {name}{suffix}")
 

--- a/src/coderrr/verify.py
+++ b/src/coderrr/verify.py
@@ -119,7 +119,7 @@ class Verifier:
                     tools=[],
                     model=self.model,
                     max_tokens=300,
-                    temperature=0.0,
+                    temperature=self.config.temperature,
                 )
             )
         except ProviderError as exc:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,95 @@
+"""Console output must survive a terminal that cannot encode what we print.
+
+Windows consoles default to cp1252 or cp437, and both reject most of the icon
+set. CI caught it the only way it can be caught -- running a real command on a
+real Windows runner, where ``coderrr doctor`` died on the info icon.
+
+``sys.stdout`` is patched inside each test body rather than from a fixture:
+pytest's capture manager reassigns ``sys.stdout`` between the setup and call
+phases, so a patch applied during setup is silently undone before the test runs.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from coderrr.ui.console import _ASCII_ICONS, _ICONS, Console
+
+
+def _fake_stdout(
+    monkeypatch: pytest.MonkeyPatch, encoding: str
+) -> tuple[io.BytesIO, io.TextIOWrapper]:
+    """Point ``sys.stdout`` at a stream with ``encoding`` and strict errors."""
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding=encoding, errors="strict")
+    monkeypatch.setattr(sys, "stdout", stream)
+    return raw, stream
+
+
+def test_unicode_icons_on_a_utf8_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_stdout(monkeypatch, "utf-8")
+    assert Console()._icons is _ICONS
+
+
+@pytest.mark.parametrize("encoding", ["cp1252", "cp437", "ascii"])
+def test_ascii_icons_when_the_terminal_cannot_encode_them(
+    monkeypatch: pytest.MonkeyPatch, encoding: str
+) -> None:
+    _fake_stdout(monkeypatch, encoding)
+    assert Console()._icons is _ASCII_ICONS
+
+
+def test_ascii_icons_are_encodable_everywhere() -> None:
+    for encoding in ("cp1252", "cp437", "ascii"):
+        "".join(_ASCII_ICONS.values()).encode(encoding)
+
+
+def test_icon_tables_cover_the_same_keys() -> None:
+    assert _ICONS.keys() == _ASCII_ICONS.keys()
+
+
+def test_chrome_prints_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    raw, stream = _fake_stdout(monkeypatch, "cp1252")
+    ui = Console(interactive=False)
+
+    ui.info("info")
+    ui.success("success")
+    ui.warning("warning")
+    ui.error("error")
+    ui.tool_call("read_file", "src/coderrr/cli.py")
+    ui.tool_result("read_file", True, "42 lines")
+    ui.tool_result("read_file", False)
+
+    stream.flush()
+    assert raw.getvalue(), "nothing reached the stream"
+
+
+def test_model_generated_text_degrades_instead_of_crashing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unencodable model output must not raise -- we cannot enumerate it.
+
+    A spec containing an arrow or a box-drawing character is ordinary output.
+    Printing one used to take the whole command down partway through.
+    """
+    raw, stream = _fake_stdout(monkeypatch, "cp1252")
+    ui = Console(interactive=False)
+
+    ui.markdown("## Data Flow\n\nRequest → API ─▶ worker\n")
+    ui.info("sandbox: scratch — no isolation")
+
+    stream.flush()
+    written = raw.getvalue()
+    assert written, "nothing reached the stream"
+    assert b"?" in written, "unencodable characters should be replaced, not dropped"
+
+
+def test_quiet_console_still_selects_icons(monkeypatch: pytest.MonkeyPatch) -> None:
+    """QuietConsole runs the same __init__; it must not crash on a legacy stream."""
+    from coderrr.ui.console import QuietConsole
+
+    _fake_stdout(monkeypatch, "cp1252")
+    assert QuietConsole()._icons is _ASCII_ICONS

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -4,19 +4,34 @@ Windows consoles default to cp1252 or cp437, and both reject most of the icon
 set. CI caught it the only way it can be caught -- running a real command on a
 real Windows runner, where ``coderrr doctor`` died on the info icon.
 
-``sys.stdout`` is patched inside each test body rather than from a fixture:
-pytest's capture manager reassigns ``sys.stdout`` between the setup and call
-phases, so a patch applied during setup is silently undone before the test runs.
+Two rules apply here, learned from getting them wrong:
+
+* Assert on ``_encodable`` and ``_icons_for`` rather than on a ``Console``
+  built for the host. Icon choice depends on ``legacy_windows``, so a test that
+  goes through ``Console()`` asserts something different on a Windows runner
+  than it does on Linux. Only properties true on every platform belong in the
+  integration tests below.
+* Patch ``sys.stdout`` inside the test body, never from a fixture. pytest's
+  capture manager reassigns it between the setup and call phases, so a patch
+  applied during setup is silently undone before the test runs.
 """
 
 from __future__ import annotations
 
 import io
 import sys
+from typing import IO, cast
 
 import pytest
 
-from coderrr.ui.console import _ASCII_ICONS, _ICONS, Console
+from coderrr.ui.console import (
+    _ASCII_ICONS,
+    _ICONS,
+    Console,
+    QuietConsole,
+    _encodable,
+    _icons_for,
+)
 
 
 def _fake_stdout(
@@ -29,17 +44,41 @@ def _fake_stdout(
     return raw, stream
 
 
-def test_unicode_icons_on_a_utf8_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
-    _fake_stdout(monkeypatch, "utf-8")
-    assert Console()._icons is _ICONS
+# -- the decision, isolated from the host --------------------------------------
 
 
-@pytest.mark.parametrize("encoding", ["cp1252", "cp437", "ascii"])
-def test_ascii_icons_when_the_terminal_cannot_encode_them(
-    monkeypatch: pytest.MonkeyPatch, encoding: str
-) -> None:
-    _fake_stdout(monkeypatch, encoding)
-    assert Console()._icons is _ASCII_ICONS
+@pytest.mark.parametrize(
+    ("encodable", "legacy_windows", "expected"),
+    [
+        (True, False, _ICONS),
+        (True, True, _ASCII_ICONS),  # a legacy console that could encode anyway
+        (False, False, _ASCII_ICONS),
+        (False, True, _ASCII_ICONS),
+    ],
+)
+def test_icon_choice(encodable: bool, legacy_windows: bool, expected: dict[str, str]) -> None:
+    assert _icons_for(encodable=encodable, legacy_windows=legacy_windows) is expected
+
+
+@pytest.mark.parametrize(
+    ("encoding", "expected"),
+    [("utf-8", True), ("cp1252", False), ("cp437", False), ("ascii", False)],
+)
+def test_encodable_follows_the_stream_encoding(encoding: str, expected: bool) -> None:
+    stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+    assert _encodable("".join(_ICONS.values()), stream) is expected
+
+
+def test_encodable_allows_a_stream_with_no_encoding() -> None:
+    """An in-memory buffer never runs the encode step, so nothing can fail."""
+    assert _encodable("◇", cast(IO[str], io.StringIO())) is True
+
+
+def test_encodable_rejects_an_unknown_codec() -> None:
+    class Stub:
+        encoding = "definitely-not-a-codec"
+
+    assert _encodable("◇", cast(IO[str], Stub())) is False
 
 
 def test_ascii_icons_are_encodable_everywhere() -> None:
@@ -49,6 +88,21 @@ def test_ascii_icons_are_encodable_everywhere() -> None:
 
 def test_icon_tables_cover_the_same_keys() -> None:
     assert _ICONS.keys() == _ASCII_ICONS.keys()
+
+
+# -- integration: properties that hold on every platform -----------------------
+
+
+def test_a_stream_that_cannot_encode_gets_ascii_icons(monkeypatch: pytest.MonkeyPatch) -> None:
+    """False for `encodable` forces ASCII regardless of the host platform."""
+    _fake_stdout(monkeypatch, "cp1252")
+    assert Console()._icons is _ASCII_ICONS
+
+
+def test_quiet_console_selects_icons_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    """QuietConsole runs the same __init__; it must not crash on a legacy stream."""
+    _fake_stdout(monkeypatch, "cp1252")
+    assert QuietConsole()._icons is _ASCII_ICONS
 
 
 def test_chrome_prints_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -87,9 +141,12 @@ def test_model_generated_text_degrades_instead_of_crashing(
     assert b"?" in written, "unencodable characters should be replaced, not dropped"
 
 
-def test_quiet_console_still_selects_icons(monkeypatch: pytest.MonkeyPatch) -> None:
-    """QuietConsole runs the same __init__; it must not crash on a legacy stream."""
-    from coderrr.ui.console import QuietConsole
+def test_a_utf8_stream_is_not_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing is substituted when the stream can carry it, legacy host or not."""
+    raw, stream = _fake_stdout(monkeypatch, "utf-8")
+    ui = Console(interactive=False)
 
-    _fake_stdout(monkeypatch, "cp1252")
-    assert QuietConsole()._icons is _ASCII_ICONS
+    ui.info("sandbox: scratch — no isolation")
+
+    stream.flush()
+    assert "—".encode() in raw.getvalue()


### PR DESCRIPTION
This pull request makes several improvements to the CI workflow and codebase, focusing on workflow reliability, configuration flexibility, and error reporting clarity. The most notable changes are stricter and more robust CI workflows, improved error messages for HTTP failures, and enhanced configurability for verification steps.

**CI Workflow Improvements:**

- Updated `.github/workflows/v2.yml` to use stricter concurrency controls, improved branch workflow validation, and more descriptive comments. Added timeouts and environment variable settings to all jobs, and simplified the test matrix to cover only essential OS/Python combinations. [[1]](diffhunk://#diff-d4161399119989ab059e761bc1abadbf9711a0075d02bae8a09b5a481b48f170L3-R28) [[2]](diffhunk://#diff-d4161399119989ab059e761bc1abadbf9711a0075d02bae8a09b5a481b48f170L44-R55) [[3]](diffhunk://#diff-d4161399119989ab059e761bc1abadbf9711a0075d02bae8a09b5a481b48f170R69-R98) [[4]](diffhunk://#diff-d4161399119989ab059e761bc1abadbf9711a0075d02bae8a09b5a481b48f170R108-R115) [[5]](diffhunk://#diff-d4161399119989ab059e761bc1abadbf9711a0075d02bae8a09b5a481b48f170R130)

**Configuration Enhancements:**

- Added a `temperature` field to the `VerifyConfig` model in `src/coderrr/config.py`, allowing the sampling temperature for verifier calls to be set in the config. This helps avoid deterministic failures in retries.
- Updated `src/coderrr/verify.py` to use the configurable `temperature` value in verifier LLM calls.

**Error Reporting Improvements:**

- Improved error messages in LLM provider modules (`src/coderrr/llm/anthropic.py`, `src/coderrr/llm/google.py`, `src/coderrr/llm/openai_compat.py`) to ensure that empty exception messages (e.g., from timeouts) fall back to the exception class name, making failures easier to diagnose. [[1]](diffhunk://#diff-86c68cd5658d0d76e4dcb56c7bdd1ff3bc05569249c2ae0e83931de900e67aedL202-R205) [[2]](diffhunk://#diff-2714035a67ecf51b47c1d9e65ab88db1cce89232ccf7a9258c1cc19cab7c95e0L198-R201) [[3]](diffhunk://#diff-c7ac2e6ee2374f00cd11d5a1a9ffabdd516eeac9676fa2a4b1deee102655737aL216-R220)

**Documentation and Contribution Guidelines:**

- Added `CLAUDE.md` with explicit restrictions and workflow guidelines for AI contributors, specifying that only read-only git commands are allowed and that all actions require prior approval.